### PR TITLE
refact: 调整单元测试案例代码，提高成功率

### DIFF
--- a/easytrans-starter/src/test/java/com/yiqiniu/easytrans/test/FullTest.java
+++ b/easytrans-starter/src/test/java/com/yiqiniu/easytrans/test/FullTest.java
@@ -171,20 +171,22 @@ public class FullTest {
 		}
 
 
-		sleep(10000);// wait for msg queue retry test finished
 		// 执行一遍后台补偿任务，以避免上述操作有未补偿成功的
 		// execute consistent guardian in case of timeout
 		List<LogCollection> unfinishedLogs = logReader.getUnfinishedLogs(null, 100, new Date());
 		for (LogCollection logCollection : unfinishedLogs) {
 			guardian.process(logCollection);
 		}
-
+		
+		sleep(20000);// wait for msg queue retry test finished
+		
 		Assert.assertTrue(walletService.getUserTotalAmount(1) == 5000);
 		Assert.assertTrue(walletService.getUserFreezeAmount(1) == 0);
 		Assert.assertTrue(accountingService.getTotalCost(1) == 5000);
 		Assert.assertTrue(expressService.getUserExpressCount(1) == 5);
 		Assert.assertTrue(pointService.getUserPoint(1) == 7000);
 		System.out.println("Test Passed!!");
+	
 	}
 
 	public void sleep(long sleepTime) {

--- a/easytrans-starter/src/test/java/com/yiqiniu/easytrans/test/mockservice/order/OrderService.java
+++ b/easytrans-starter/src/test/java/com/yiqiniu/easytrans/test/mockservice/order/OrderService.java
@@ -172,14 +172,23 @@ public class OrderService {
 		 */
 		WalletPayTccMethodRequest deductRequest = new WalletPayTccMethodRequest();
 		deductRequest.setUserId(userId);
-		deductRequest.setPayAmount(money/2);
+		deductRequest.setPayAmount(money/10);
 		//return future for the benefits of performance enhance(batch write execute log and batch execute RPC)
 		//返回future是为了能方便的优化性能(批量写日志及批量调用RPC)
 		Future<WalletPayTccMethodResult> deductFuture = null;
 		if(checkExecuteForTestCase(deductRequest.getClass())){
 			/**
-			 * 执行两遍，每次都扣一半的钱，以测试相同方法在业务上调用两次的场景
+			 * 执行10遍，每次都扣十分之一钱，以测试相同方法在业务上调用多次的场景
+			 * 因之前版本不支持同一事物内调用同一个方法多次，这里只是测试调用多次的场景，并无其他特殊含义
 			 */
+			deductFuture = transaction.execute(deductRequest);
+			deductFuture = transaction.execute(deductRequest);
+			deductFuture = transaction.execute(deductRequest);
+			deductFuture = transaction.execute(deductRequest);
+			deductFuture = transaction.execute(deductRequest);
+			deductFuture = transaction.execute(deductRequest);
+			deductFuture = transaction.execute(deductRequest);
+			deductFuture = transaction.execute(deductRequest);
 			deductFuture = transaction.execute(deductRequest);
 			deductFuture = transaction.execute(deductRequest);
 		}


### PR DESCRIPTION
* 在FullTest的Assert前，将主动后台补偿调整到SLEEP之前，以便相关补偿操作发起后有足够的时间进行异步处理
* 调大Sleep的时间，以避免消息重发的UT案例执行时间不够（其会主动失败4次，第五次才会消费成功）