### PR TITLE
try前增加@Transactional，导致启动失败的bug修复

### DIFF
--- a/easytrans-core/src/main/java/com/yiqiniu/easytrans/provider/factory/DefaultListableProviderFactory.java
+++ b/easytrans-core/src/main/java/com/yiqiniu/easytrans/provider/factory/DefaultListableProviderFactory.java
@@ -66,7 +66,9 @@ public class DefaultListableProviderFactory implements ListableProviderFactory {
 					Class<?> transactionType = transactionTypeList.getKey();
 					if(transactionType.isAssignableFrom(bean.getClass())){
 						transactionTypeList.getValue().add(bean);
-						Class<? extends EasyTransRequest<?, ?>> requestClass = ReflectUtil.getRequestClass((Class<? extends BusinessProvider<?>>) bean.getClass());
+						//modify by lisq 20180912 supports proxy
+						Object orgObject = ReflectUtil.getOriginalObject(bean);
+						Class<? extends EasyTransRequest<?, ?>> requestClass = ReflectUtil.getRequestClass((Class<? extends BusinessProvider<?>>) orgObject.getClass());
 						BusinessIdentifer businessIdentifer = ReflectUtil.getBusinessIdentifer(requestClass);
 						if(businessIdentifer == null){
 							throw new RuntimeException("request class did not add Annotation BusinessIdentifer,please add it! class:" + requestClass);

--- a/easytrans-core/src/main/java/com/yiqiniu/easytrans/rpc/EasyTransRpcProviderInitializer.java
+++ b/easytrans-core/src/main/java/com/yiqiniu/easytrans/rpc/EasyTransRpcProviderInitializer.java
@@ -45,6 +45,8 @@ public class EasyTransRpcProviderInitializer {
 			HashMap<BusinessIdentifer,RpcBusinessProvider<?>> map = new HashMap<BusinessIdentifer, RpcBusinessProvider<?>>(services.size());
 			for(Object serviceObject:services){
 				RpcBusinessProvider<?> provider = (RpcBusinessProvider<?>) serviceObject;
+				// modify by lisq  20180912 supports proxy
+				provider =  ReflectUtil.getOriginalObject(provider);
 				Class<? extends EasyTransRequest<?, ?>> requestClass = ReflectUtil.getRequestClass((Class<? extends BusinessProvider<?>>) provider.getClass());
 				BusinessIdentifer businessIdentifer = ReflectUtil.getBusinessIdentifer(requestClass);
 				map.put(businessIdentifer, provider);


### PR DESCRIPTION
问题原因：获取注解时得到的是代理对象，因此会得不到注解
解决方式：判断代理方式如果是代理类，则通过代理对象获取原始对象，再取注解