### PR TITLE
fix: 修复自定义数据表 str_codec 前缀时查询语句错误的问题

### DIFF
--- a/easytrans-extensionsuite-database-starter/readme.md
+++ b/easytrans-extensionsuite-database-starter/readme.md
@@ -14,9 +14,9 @@ create table in mysql, it's not necessary to use the same database of business(b
 
     CREATE TABLE `str_codec` (
       `key_int` int(11) NOT NULL,
-      `str_type` varchar(45) NOT NULL,
+      `type_str` varchar(45) NOT NULL,
       `value_str` varchar(2000) NOT NULL,
       `create_time` datetime NOT NULL,
       PRIMARY KEY (`key_int`),
-      UNIQUE KEY `str_type_UNIQUE` (`str_type`,`value_str`)
+      UNIQUE KEY `str_type_UNIQUE` (`type_str`,`value_str`)
     ) ENGINE=InnoDB;

--- a/easytrans-extensionsuite-database-starter/src/main/java/com/yiqiniu/easytrans/extensionsuite/impl/database/DatabaseStringCodecImpl.java
+++ b/easytrans-extensionsuite-database-starter/src/main/java/com/yiqiniu/easytrans/extensionsuite/impl/database/DatabaseStringCodecImpl.java
@@ -86,6 +86,7 @@ public class DatabaseStringCodecImpl implements ListableStringCodec {
             GET_MAX_ID_AND_LOCK = addTablePrefix(tablePrefix, GET_MAX_ID_AND_LOCK);
             GET_KEY_AND_LOCK = addTablePrefix(tablePrefix, GET_KEY_AND_LOCK);
             GET_ALL = addTablePrefix(tablePrefix, GET_ALL);
+            GET_BY_ID = addTablePrefix(tablePrefix, GET_BY_ID);
         }
         
         List<DataObject> result = jdbcTemplate.query(GET_ALL, dataObjectMapper);


### PR DESCRIPTION
1. 问题1：初始化 `DatabaseStringCodecImpl` 时，没有为语句 `GET_BY_ID` 添加前缀名
![image](https://user-images.githubusercontent.com/11768760/80111525-91805100-85b2-11ea-9184-f30e13634d08.png)
在调用 `findString` 时会抛出异常 `MySQLSyntaxErrorException: Table 'str_codec' doesn't exist`
![image](https://user-images.githubusercontent.com/11768760/80111622-b4126a00-85b2-11ea-861e-9037be64461f.png)

2. 问题2：README 中 `str_codec` DDL 的字段 `str_type` 错误
![image](https://user-images.githubusercontent.com/11768760/80111933-18352e00-85b3-11ea-84f0-9d974a35e283.png)
下图是代码中使用的字段 `type_str`
![image](https://user-images.githubusercontent.com/11768760/80112075-431f8200-85b3-11ea-83a0-ad4937c1e5ea.png)
