### PR TITLE
fix: 修复 rollback 类型日志对事务状态判断错误的问题

### DIFF
--- a/easytrans-core/src/main/java/com/yiqiniu/easytrans/context/LogProcessContext.java
+++ b/easytrans-core/src/main/java/com/yiqiniu/easytrans/context/LogProcessContext.java
@@ -16,10 +16,7 @@ import com.yiqiniu.easytrans.core.ExecuteCacheManager;
 import com.yiqiniu.easytrans.datasource.TransStatusLogger;
 import com.yiqiniu.easytrans.log.LogCache;
 import com.yiqiniu.easytrans.log.TransactionLogWritter;
-import com.yiqiniu.easytrans.log.vo.AfterCommit;
-import com.yiqiniu.easytrans.log.vo.Content;
-import com.yiqiniu.easytrans.log.vo.DemiLeftContent;
-import com.yiqiniu.easytrans.log.vo.LogCollection;
+import com.yiqiniu.easytrans.log.vo.*;
 import com.yiqiniu.easytrans.protocol.TransactionId;
 
 
@@ -184,7 +181,7 @@ public class LogProcessContext{
 	private boolean isRollBackLog(Class<? extends Content> contentClass){
 		Boolean isRollbackedLogContent = mapRollBackLogContent.get(contentClass);
 		if(isRollbackedLogContent == null){
-			isRollbackedLogContent = hasAnnotion(contentClass,AfterCommit.class);
+			isRollbackedLogContent = hasAnnotion(contentClass,AfterRollBack.class);
 			mapRollBackLogContent.put(contentClass, isRollbackedLogContent);
 		}
 		return isRollbackedLogContent;


### PR DESCRIPTION
**问题：**
在获取主事务状态时，使用了 `AfterCommit` 判断是否 rollback 类型事务。

**解决：**
使用 `AfterRollback` 进行判断。

**请教一个问题**
设计 `DemiRightContent` 类型的事务内容目的是解决什么问题？