### PR TITLE
refactor: 修改事务传播级别为 REQUIRED，允许与主事务使用同一个事务

### DIFF
--- a/easytrans-log-database-starter/src/main/java/com/yiqiniu/easytrans/log/impl/database/DataBaseTransactionLogWritterImpl.java
+++ b/easytrans-log-database-starter/src/main/java/com/yiqiniu/easytrans/log/impl/database/DataBaseTransactionLogWritterImpl.java
@@ -44,7 +44,7 @@ public class DataBaseTransactionLogWritterImpl implements TransactionLogWritter 
 		this.idCodec = idCodec;
 		this.dataSource = dataSource;
 		transactionManager = new DataSourceTransactionManager(dataSource);
-		transactionTemplate = new TransactionTemplate(transactionManager, new DefaultTransactionDefinition(TransactionDefinition.PROPAGATION_REQUIRES_NEW));
+		transactionTemplate = new TransactionTemplate(transactionManager, new DefaultTransactionDefinition(TransactionDefinition.PROPAGATION_REQUIRED));
 		
 		if(!StringUtils.isEmpty(tablePrefix)) {
 			tablePrefix = tablePrefix.trim();


### PR DESCRIPTION
**问题**
1. 主事务在提交之前 crash，未完成事务和事务内容已经被存储到数据库中，导致服务启动后再次执行不必要的操作（虽然执行了一些操作，结果是正确的）。

**原因**
1. 创建 `DataBaseTransactionLogWritterImpl` 时使用 `PROPAGATION_REQUIRES_NEW` 传播级别，创建事务日志时无法与主事务使用同一个事务。
2. `DatabaseExtensionsSuiteConfiguration` 和 `DataBaseTransactionLogConfiguration`  创建 `DataBaseTransactionLogWritterImpl` 时都是使用 EasyTrans 创建的数据源，导致创建日志时无法与主事务使用同一个事务。

**为什么可以优化**
1. `DataBaseTransactionLogWritterImpl` 创建日志记录时，在 `beforeCommit` 与主事务之间是同步操作（同一个线程），如果使用用户程序的数据源，可以与主事务的使用同一个事务管理。
2. `DataBaseTransactionLogWritterImpl#appendTransLog` 没有在 `afterCompletion` 和 `afterCommit` 中执行。
3. `DataBaseTransactionLogWritterImpl#appendTransLog` 除了第 1 点的情况，其他执行场景与用户事务（主事务）无关，不会因为用户事务回滚导致无法正常完成事务。
4. `DataBaseTransactionLogWritterImpl#cleanFinishedLogs` 由一个异步线程执行。