### PR TITLE
fix: 修复数据库选主实现类在时间跨度大于35天时 SQL 报错的问题

### DIFF
--- a/easytrans-extensionsuite-database-starter/src/main/java/com/yiqiniu/easytrans/extensionsuite/impl/database/DatabaseMasterSelectorImpl.java
+++ b/easytrans-extensionsuite-database-starter/src/main/java/com/yiqiniu/easytrans/extensionsuite/impl/database/DatabaseMasterSelectorImpl.java
@@ -33,9 +33,9 @@ public class DatabaseMasterSelectorImpl implements EasyTransMasterSelector {
 
     private String GET_MAX_INSTANCE_ID = "select ifnull(max(instance_id),0)  max_instance_id  from election where app_id  = ? for update";
     private String INSERT_INSTANCE_CONTROL_LINE = "insert into election values(?, ?,now(),?)";
-    private String UPDATE_HEARTBEAT_TIME = "update election set heart_beat_time = now() where app_id = ? and instance_id = ? and TIME_TO_SEC(TIMEDIFF(NOW(), heart_beat_time)) <= ?";
-    private String GET_MASTER_INSTANCE = "select min(instance_id) from election where app_id = ? and TIME_TO_SEC(TIMEDIFF(NOW(), heart_beat_time)) <= ?";
-    private String CLEAN_EXPIRED_INSTANCE_RECORD = "delete from election where app_id = ? and TIME_TO_SEC(TIMEDIFF(NOW(), heart_beat_time)) > ?";
+    private String UPDATE_HEARTBEAT_TIME = "update election set heart_beat_time = now() where app_id = ? and instance_id = ? and TIMESTAMPDIFF(SECOND, heart_beat_time, NOW()) <= ?";
+    private String GET_MASTER_INSTANCE = "select min(instance_id) from election where app_id = ? and TIMESTAMPDIFF(SECOND, heart_beat_time, NOW()) <= ?";
+    private String CLEAN_EXPIRED_INSTANCE_RECORD = "delete from election where app_id = ? and TIMESTAMPDIFF(SECOND, heart_beat_time, NOW()) > ?";
 	
 	
     private volatile Integer instanceId;


### PR DESCRIPTION
# 问题
使用数据库选主，当历史心跳记录距今大于 3020399 秒，删除这些过期心跳记录时会报错。

详细日志：
```
2020-07-14 22:02:50.491 ERROR 7036 --- [pool-3-thread-1] c.y.e.e.i.d.DatabaseMasterSelectorImpl   : heart beat failed!38

org.springframework.dao.DataIntegrityViolationException: PreparedStatementCallback; SQL [delete from trx_election where app_id = ? and TIME_TO_SEC(TIMEDIFF(NOW(), heart_beat_time)) > ?]; Data truncation: Truncated incorrect time value: '1797:03:18'; nested exception is com.mysql.jdbc.MysqlDataTruncation: Data truncation: Truncated incorrect time value: '1797:03:18'
	at org.springframework.jdbc.support.SQLStateSQLExceptionTranslator.doTranslate(SQLStateSQLExceptionTranslator.java:102)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:73)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:82)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:82)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:655)
	at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:876)
	at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:937)
	at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:947)
	at com.yiqiniu.easytrans.extensionsuite.impl.database.DatabaseMasterSelectorImpl.updateHeartBeat(DatabaseMasterSelectorImpl.java:84)
	at com.yiqiniu.easytrans.extensionsuite.impl.database.DatabaseMasterSelectorImpl.access$0(DatabaseMasterSelectorImpl.java:72)
	at com.yiqiniu.easytrans.extensionsuite.impl.database.DatabaseMasterSelectorImpl$1.run(DatabaseMasterSelectorImpl.java:67)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: com.mysql.jdbc.MysqlDataTruncation: Data truncation: Truncated incorrect time value: '1797:03:18'
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3931)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3869)
	at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2524)
	at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2675)
	at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2465)
	at com.mysql.jdbc.PreparedStatement.executeInternal(PreparedStatement.java:1912)
	at com.mysql.jdbc.PreparedStatement.executeUpdateInternal(PreparedStatement.java:2133)
	at com.mysql.jdbc.PreparedStatement.executeUpdateInternal(PreparedStatement.java:2067)
	at com.mysql.jdbc.PreparedStatement.executeLargeUpdate(PreparedStatement.java:5175)
	at com.mysql.jdbc.PreparedStatement.executeUpdate(PreparedStatement.java:2052)
	at com.alibaba.druid.pool.DruidPooledPreparedStatement.executeUpdate(DruidPooledPreparedStatement.java:256)
	at org.springframework.jdbc.core.JdbcTemplate$2.doInPreparedStatement(JdbcTemplate.java:883)
	at org.springframework.jdbc.core.JdbcTemplate$2.doInPreparedStatement(JdbcTemplate.java:876)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:639)
	... 13 common frames omitted
```

# 环境
版本：1.4.3

# 原因
[MySQL 文档 - TIMEDIFF](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff) 描述了 `TIMEDIFF` 的范围是  '-838:59:59' - '838:59:59'。因此，当时间差大于约35天时，DML 语句报错。